### PR TITLE
Fix reference to twelve-lines to be ten-lines

### DIFF
--- a/test/avi/core_test.clj
+++ b/test/avi/core_test.clj
@@ -31,7 +31,7 @@
 
 (facts "regarding scrolling"
   (fact "line-wise cursor movement will keep the cursor in the viewport"
-    (editor :when-editing twelve-lines :after-typing "8j")
+    (editor :when-editing ten-lines :after-typing "8j")
     ))
 
 (facts "regarding quitting"


### PR DESCRIPTION
``` bash
$ lein midje :print-facts
= Namespace avi.core-test
Checking regarding displaying of a loaded file
Exception in thread "main" java.lang.RuntimeException: Unable to resolve symbol: twelve-lines in this context, compiling:(avi/core_test.clj:32:1)
```
