### PR TITLE
Make `gg` and `G` move to the first character of the target line

### DIFF
--- a/src/avi/normal_mode.clj
+++ b/src/avi/normal_mode.clj
@@ -149,8 +149,11 @@
             last-line (dec (b/line-count buffer))
             target-line (if repeat-count
                           (dec repeat-count)
-                          last-line)]
-        (change-line editor (constantly target-line))))
+                          last-line)
+            target-column (index-of-first-non-blank (b/line buffer target-line))]
+        (-> editor
+            (change-line (constantly target-line))
+            (change-column (constantly target-column)))))
 
     ("H"
       [editor repeat-count]

--- a/test/avi/normal_mode_test.clj
+++ b/test/avi/normal_mode_test.clj
@@ -82,10 +82,10 @@
       (cursor :editing "   " :after "0^") => [0 2]))
 
   (facts "about `G`"
-    (fact "`G` moves to the last line."
-      (cursor :editing ".\n.\nThree" :after "G") => [2 0])
-    (fact "`G` moves to the line in the count register."
-      (cursor :editing ".\n.\nThree" :after "2G") => [1 0])))
+    (fact "`G` moves to the first non-blank character on the last line"
+      (cursor :editing "...\n...\n Three" :after "llG") => [2 1])
+    (fact "`G` moves to the first non-blank character on the line in the count register."
+      (cursor :editing "...\n ...\nThree" :after "ll2G") => [1 1])))
 
 (facts "regarding scrolling"
   (fact "line-wise cursor movement will keep the cursor in the viewport"


### PR DESCRIPTION
This is how Vim behaves, so I guess we should do the same.
