### PR TITLE
Fixed a bug with capital O

### DIFF
--- a/src/avi/normal_mode.clj
+++ b/src/avi/normal_mode.clj
@@ -249,7 +249,8 @@
           (let [{[i] :cursor} (e/current-buffer editor)]
             (e/enter-mode :insert :script-prefix [[:keystroke "<Enter>"]])
             (in e/current-buffer
-                (b/insert-blank-line i)))))
+                (b/insert-blank-line i))
+            (change-column (constantly 0)))))
 
     ("<C-D>"
       [editor]

--- a/test/avi/insert_mode_test.clj
+++ b/test/avi/insert_mode_test.clj
@@ -63,7 +63,7 @@
           "test.txt" :black :on :white
           ""])
   (fact "`Oxy<Esc>` inserts a line here"
-    (terminal :editing "One\nTwo\nThree..." :after "Oxy<Esc>")
+    (terminal :editing "One\nTwo\nThree..." :after "llOxy<Esc>")
       => ["xy"
           "One"
           "Two"


### PR DESCRIPTION
Using `O` wasn't working properly when the cursor was anywhere past the first column. I took a shot at correcting it by shifting the cursor into the first position after inserting the new line.
