### PR TITLE
Added support for arrow keys in insert mode mimicking vim

### DIFF
--- a/src/avi/mode/insert.clj
+++ b/src/avi/mode/insert.clj
@@ -122,10 +122,14 @@
 (def wrap-handle-right
   (e/keystroke-middleware "<Right>"
     (fn+> [editor]
-      (in e/edit-context
-        (ec/operate {:operator :move-point
-                     :motion [:right]})
-        ec/commit))))
+      (let [{[i j] :point lines :lines } (e/edit-context editor)
+             eol (dec (count (get lines i)))]
+        (in e/edit-context
+          (if (<= eol j)
+            move-to-eol
+            (ec/operate {:operator :move-point
+                       :motion [:right]}))
+          ec/commit)))))
 
 (def wrap-handle-left
   (e/keystroke-middleware "<Left>"

--- a/src/avi/mode/insert.clj
+++ b/src/avi/mode/insert.clj
@@ -103,6 +103,38 @@
           ec/commit))
       (e/enter-normal-mode))))
 
+(def wrap-handle-up
+  (e/keystroke-middleware "<Up>"
+    (fn+> [editor]
+      (in e/edit-context
+        (ec/operate {:operator :move-point
+                     :motion [:up]})
+        ec/commit))))
+
+(def wrap-handle-down
+  (e/keystroke-middleware "<Down>"
+    (fn+> [editor]
+      (in e/edit-context
+        (ec/operate {:operator :move-point
+                     :motion [:down]})
+        ec/commit))))
+
+(def wrap-handle-right
+  (e/keystroke-middleware "<Right>"
+    (fn+> [editor]
+      (in e/edit-context
+        (ec/operate {:operator :move-point
+                     :motion [:right]})
+        ec/commit))))
+
+(def wrap-handle-left
+  (e/keystroke-middleware "<Left>"
+    (fn+> [editor]
+      (in e/edit-context
+        (ec/operate {:operator :move-point
+                     :motion [:left]})
+        ec/commit))))
+
 (defn- wrap-record-event
   [responder]
   (fn+> [editor event]
@@ -112,6 +144,10 @@
 (def responder
   (-> update-edit-context-for-insert-event
       wrap-record-event
+      wrap-handle-up
+      wrap-handle-down
+      wrap-handle-right
+      wrap-handle-left
       wrap-handle-escape))
 
 (def wrap-mode (e/mode-middleware :insert responder))


### PR DESCRIPTION
Added support for arrow keys in insert mode according to vim functionality.

I have tried various methods to get this functionality working. The checked in code achieves the functionality required and passes all the test cases. I am not sure if this is the right way to achieve the functionality. Do review and give your feedback.

Also added support for right arrow to go to the end of line while editing as is functionality in vim.